### PR TITLE
Default to not writing a pidfile unless daemonized

### DIFF
--- a/lib/crono/cli.rb
+++ b/lib/crono/cli.rb
@@ -50,6 +50,7 @@ module Crono
     end
 
     def write_pid
+      return unless config.pidfile
       pidfile = File.expand_path(config.pidfile)
       File.write(pidfile, ::Process.pid)
     end

--- a/lib/crono/config.rb
+++ b/lib/crono/config.rb
@@ -10,9 +10,12 @@ module Crono
     def initialize
       self.cronotab = CRONOTAB
       self.logfile  = LOGFILE
-      self.pidfile  = PIDFILE
       self.daemonize = false
       self.environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+    end
+
+    def pidfile
+      @pidfile || (daemonize ? PIDFILE : nil)
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,15 +1,42 @@
 require 'spec_helper'
 
 describe Crono::Config do
+  let(:config) { Crono::Config.new }
   describe '#initialize' do
     it 'should initialize with default configuration options' do
       ENV['RAILS_ENV'] = 'test'
       @config = Crono::Config.new
       expect(@config.cronotab).to be Crono::Config::CRONOTAB
       expect(@config.logfile).to be Crono::Config::LOGFILE
-      expect(@config.pidfile).to be Crono::Config::PIDFILE
+      expect(@config.pidfile).to be nil
       expect(@config.daemonize).to be false
       expect(@config.environment).to be_eql ENV['RAILS_ENV']
+    end
+
+    describe "#pidfile" do
+      subject(:pidfile) { config.pidfile }
+
+      context "not explicity configured" do
+        context "daemonize is false" do
+          before { config.daemonize = false }
+
+          specify { expect(pidfile).to be_nil }
+        end
+
+        context "daemonize is true" do
+          before { config.daemonize = true }
+
+          specify { expect(pidfile).to eq Crono::Config::PIDFILE }
+        end
+      end
+
+      context "explicity configured" do
+        let(:path) { "foo/bar/pid.pid" }
+
+        before { config.pidfile = path }
+
+        specify { expect(pidfile).to eq path }
+      end
     end
   end
 end


### PR DESCRIPTION
Pidfiles are generally only used when you have a daemonized process. In other circumstances they are superfluous and can actually cause issues (e.g. deploying to Heroku with no `tmp` directory).

This PR enables pidfiles by default only when daemonized, although the pidfile can always be explicity enabled.