### PR TITLE
Add the possibility to schedule jobs with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ class TestJob < ActiveJob::Base
 end
 ```
 
-The ActiveJob jobs is convenient because you can use one job in both periodic and enqueued ways. But Active Job is not required. Any class can be used as a crono job if it implements a method `perform` without arguments:
+The ActiveJob jobs is convenient because you can use one job in both periodic and enqueued ways. But Active Job is not required. Any class can be used as a crono job if it implements a method `perform`:
 
 ```ruby
 class TestJob # This is not an Active Job job, but pretty legal Crono job.
-  def perform
+  def perform(*args)
     # put you scheduled code here
     # Comments.deleted.clean_up...
   end
@@ -122,6 +122,13 @@ The `at` can be a Hash:
 
 ```ruby
 Crono.perform(TestJob).every 1.day, at: {hour: 12, min: 15}
+```
+
+You can schedule a job with arguments, which can contain objects that can be
+serialized using JSON.generate
+
+```ruby
+Crono.perform(TestJob, 'some', 'args').every 1.day, at: {hour: 12, min: 15}
 ```
 
 #### Run daemon

--- a/lib/crono/job.rb
+++ b/lib/crono/job.rb
@@ -6,12 +6,13 @@ module Crono
   class Job
     include Logging
 
-    attr_accessor :performer, :period, :last_performed_at,
+    attr_accessor :performer, :period, :data, :last_performed_at,
                   :next_performed_at, :job_log, :job_logger, :healthy, :execution_interval
 
-    def initialize(performer, period)
+    def initialize(performer, period, data)
       self.execution_interval = 0.minutes
       self.performer, self.period = performer, period
+      self.data = JSON.generate(data) if data
       self.job_log = StringIO.new
       self.job_logger = Logger.new(job_log)
       self.next_performed_at = period.next
@@ -64,11 +65,13 @@ module Crono
       saved_log = model.reload.log || ''
       log_to_save = saved_log + job_log.string
       model.update(last_performed_at: last_performed_at, log: log_to_save,
-                   healthy: healthy)
+                   healthy: healthy, data: data)
     end
 
     def perform_job
-      performer.new.perform
+      args = []
+      args << JSON.parse(data) if data
+      performer.new(*args).perform 
     rescue StandardError => e
       handle_job_fail(e)
     else

--- a/lib/crono/performer_proxy.rb
+++ b/lib/crono/performer_proxy.rb
@@ -1,13 +1,14 @@
 module Crono
   # Crono::PerformerProxy is a proxy used in cronotab.rb semantic
   class PerformerProxy
-    def initialize(performer, scheduler)
+    def initialize(performer, scheduler, data)
       @performer = performer
       @scheduler = scheduler
+      @data = data
     end
 
     def every(period, *args)
-      @job = Job.new(@performer, Period.new(period, *args))
+      @job = Job.new(@performer, Period.new(period, *args), @data)
       @scheduler.add_job(@job)
       self
     end
@@ -18,7 +19,7 @@ module Crono
     end
   end
 
-  def self.perform(performer)
-    PerformerProxy.new(performer, Crono.scheduler)
+  def self.perform(performer, data=nil)
+    PerformerProxy.new(performer, Crono.scheduler, data)
   end
 end

--- a/lib/crono/performer_proxy.rb
+++ b/lib/crono/performer_proxy.rb
@@ -1,14 +1,14 @@
 module Crono
   # Crono::PerformerProxy is a proxy used in cronotab.rb semantic
   class PerformerProxy
-    def initialize(performer, scheduler, data)
+    def initialize(performer, scheduler, job_args)
       @performer = performer
       @scheduler = scheduler
-      @data = data
+      @job_args = job_args
     end
 
     def every(period, *args)
-      @job = Job.new(@performer, Period.new(period, *args), @data)
+      @job = Job.new(@performer, Period.new(period, *args), @job_args)
       @scheduler.add_job(@job)
       self
     end
@@ -19,7 +19,7 @@ module Crono
     end
   end
 
-  def self.perform(performer, data=nil)
-    PerformerProxy.new(performer, Crono.scheduler, data)
+  def self.perform(performer, *job_args)
+    PerformerProxy.new(performer, Crono.scheduler, job_args)
   end
 end

--- a/lib/generators/crono/install/templates/migrations/create_crono_jobs.rb
+++ b/lib/generators/crono/install/templates/migrations/create_crono_jobs.rb
@@ -5,6 +5,7 @@ class CreateCronoJobs < ActiveRecord::Migration
       t.text      :log
       t.datetime  :last_performed_at
       t.boolean   :healthy
+      t.text      :data
       t.timestamps null: false
     end
     add_index :crono_jobs, [:job_id], unique: true

--- a/lib/generators/crono/install/templates/migrations/create_crono_jobs.rb
+++ b/lib/generators/crono/install/templates/migrations/create_crono_jobs.rb
@@ -5,7 +5,7 @@ class CreateCronoJobs < ActiveRecord::Migration
       t.text      :log
       t.datetime  :last_performed_at
       t.boolean   :healthy
-      t.text      :data
+      t.text      :args
       t.timestamps null: false
     end
     add_index :crono_jobs, [:job_id], unique: true

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -2,12 +2,18 @@ require 'spec_helper'
 
 describe Crono::Job do
   let(:period) { Crono::Period.new(2.day, at: '15:00') }
-  let(:job) { Crono::Job.new(TestJob, period) }
-  let(:failing_job) { Crono::Job.new(TestFailingJob, period) }
+  let(:data) {{some: 'data'}}
+  let(:job) { Crono::Job.new(TestJob, period, nil) }
+  let(:job_with_data) { Crono::Job.new(TestJob, period, data) }
+  let(:failing_job) { Crono::Job.new(TestFailingJob, period, nil) }
 
   it 'should contain performer and period' do
     expect(job.performer).to be TestJob
     expect(job.period).to be period
+  end
+
+  it 'should contain data as JSON String' do
+    expect(job_with_data.data).to eq '{"some":"data"}'
   end
 
   describe '#next' do
@@ -56,6 +62,18 @@ describe Crono::Job do
       test_preform_job_twice
     end
 
+    it 'should call perform of performer' do
+      expect(TestJob).to receive(:new).with(no_args)
+      thread = job.perform.join
+      expect(thread).to be_stop
+    end
+
+    it 'should call perform of performer with data' do
+      expect(TestJob).to receive(:new).with({"some" => "data"})
+      thread = job_with_data.perform.join
+      expect(thread).to be_stop
+    end
+
     def test_preform_job_twice
       expect(job).to receive(:perform_job).twice
       job.perform.join
@@ -80,10 +98,12 @@ describe Crono::Job do
     it 'should update saved job' do
       job.last_performed_at = Time.now
       job.healthy = true
+      job.data = JSON.generate({some: 'data'})
       job.save
       @crono_job = Crono::CronoJob.find_by(job_id: job.job_id)
       expect(@crono_job.last_performed_at.utc.to_s).to be_eql job.last_performed_at.utc.to_s
       expect(@crono_job.healthy).to be true
+      expect(@crono_job.data).to eq '{"some":"data"}'
     end
 
     it 'should save and truncate job log' do
@@ -102,7 +122,7 @@ describe Crono::Job do
     end
 
     it 'should load last_performed_at from DB' do
-      @job = Crono::Job.new(TestJob, period)
+      @job = Crono::Job.new(TestJob, period, data)
       @job.load
       expect(@job.last_performed_at.utc.to_s).to be_eql @saved_last_performed_at.utc.to_s
     end

--- a/spec/performer_proxy_spec.rb
+++ b/spec/performer_proxy_spec.rb
@@ -18,4 +18,10 @@ describe Crono::PerformerProxy do
     expect_any_instance_of(described_class).to receive(:once_per)
     Crono.perform(TestJob).once_per 10.minutes
   end
+
+  it 'should add job with data to schedule' do
+    expect(Crono::Job).to receive(:new).with(TestJob, kind_of(Crono::Period), {some: 'data'})
+    allow(Crono.scheduler).to receive(:add_job)
+    Crono.perform(TestJob, {some: 'data'}).every(2.days, at: '15:30')
+  end
 end

--- a/spec/performer_proxy_spec.rb
+++ b/spec/performer_proxy_spec.rb
@@ -19,9 +19,9 @@ describe Crono::PerformerProxy do
     Crono.perform(TestJob).once_per 10.minutes
   end
 
-  it 'should add job with data to schedule' do
-    expect(Crono::Job).to receive(:new).with(TestJob, kind_of(Crono::Period), {some: 'data'})
+  it 'should add job with args to schedule' do
+    expect(Crono::Job).to receive(:new).with(TestJob, kind_of(Crono::Period), [:some, {some: 'data'}])
     allow(Crono.scheduler).to receive(:add_job)
-    Crono.perform(TestJob, {some: 'data'}).every(2.days, at: '15:30')
+    Crono.perform(TestJob, :some, {some: 'data'}).every(2.days, at: '15:30')
   end
 end

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -5,7 +5,7 @@ describe Crono::Scheduler do
 
   describe '#add_job' do
     it 'should call Job#load on Job' do
-      @job = Crono::Job.new(TestJob, Crono::Period.new(10.day, at: '04:05'))
+      @job = Crono::Job.new(TestJob, Crono::Period.new(10.day, at: '04:05'), nil)
       expect(@job).to receive(:load)
       scheduler.add_job(@job)
     end
@@ -17,7 +17,7 @@ describe Crono::Scheduler do
         Crono::Period.new(3.days, at: 10.minutes.from_now.strftime('%H:%M')),
         Crono::Period.new(1.day, at: 20.minutes.from_now.strftime('%H:%M')),
         Crono::Period.new(7.days, at: 40.minutes.from_now.strftime('%H:%M'))
-      ].map { |period| Crono::Job.new(TestJob, period) }
+      ].map { |period| Crono::Job.new(TestJob, period, nil) }
 
       time, jobs = scheduler.next_jobs
       expect(jobs).to be_eql [jobs[0]]
@@ -29,7 +29,7 @@ describe Crono::Scheduler do
         Crono::Period.new(1.day, at: time.strftime('%H:%M')),
         Crono::Period.new(1.day, at: time.strftime('%H:%M')),
         Crono::Period.new(1.day, at: 10.minutes.from_now.strftime('%H:%M'))
-      ].map { |period| Crono::Job.new(TestJob, period) }
+      ].map { |period| Crono::Job.new(TestJob, period, nil) }
 
       time, jobs = scheduler.next_jobs
       expect(jobs).to be_eql [jobs[0], jobs[1]]
@@ -40,7 +40,7 @@ describe Crono::Scheduler do
         Crono::Period.new(10.seconds),
         Crono::Period.new(10.seconds),
         Crono::Period.new(1.day, at: 10.minutes.from_now.strftime('%H:%M'))
-      ].map { |period| Crono::Job.new(TestJob, period) }
+      ].map { |period| Crono::Job.new(TestJob, period, nil) }
 
       _, next_jobs = scheduler.next_jobs
       expect(next_jobs).to be_eql [jobs[0]]

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -5,7 +5,7 @@ describe Crono::Scheduler do
 
   describe '#add_job' do
     it 'should call Job#load on Job' do
-      @job = Crono::Job.new(TestJob, Crono::Period.new(10.day, at: '04:05'), nil)
+      @job = Crono::Job.new(TestJob, Crono::Period.new(10.day, at: '04:05'), [])
       expect(@job).to receive(:load)
       scheduler.add_job(@job)
     end
@@ -17,7 +17,7 @@ describe Crono::Scheduler do
         Crono::Period.new(3.days, at: 10.minutes.from_now.strftime('%H:%M')),
         Crono::Period.new(1.day, at: 20.minutes.from_now.strftime('%H:%M')),
         Crono::Period.new(7.days, at: 40.minutes.from_now.strftime('%H:%M'))
-      ].map { |period| Crono::Job.new(TestJob, period, nil) }
+      ].map { |period| Crono::Job.new(TestJob, period, []) }
 
       time, jobs = scheduler.next_jobs
       expect(jobs).to be_eql [jobs[0]]
@@ -29,7 +29,7 @@ describe Crono::Scheduler do
         Crono::Period.new(1.day, at: time.strftime('%H:%M')),
         Crono::Period.new(1.day, at: time.strftime('%H:%M')),
         Crono::Period.new(1.day, at: 10.minutes.from_now.strftime('%H:%M'))
-      ].map { |period| Crono::Job.new(TestJob, period, nil) }
+      ].map { |period| Crono::Job.new(TestJob, period, []) }
 
       time, jobs = scheduler.next_jobs
       expect(jobs).to be_eql [jobs[0], jobs[1]]
@@ -40,7 +40,7 @@ describe Crono::Scheduler do
         Crono::Period.new(10.seconds),
         Crono::Period.new(10.seconds),
         Crono::Period.new(1.day, at: 10.minutes.from_now.strftime('%H:%M'))
-      ].map { |period| Crono::Job.new(TestJob, period, nil) }
+      ].map { |period| Crono::Job.new(TestJob, period, []) }
 
       _, next_jobs = scheduler.next_jobs
       expect(next_jobs).to be_eql [jobs[0]]


### PR DESCRIPTION
I implemented the possibility to schedule jobs with arguments which will be persisted using JSON.
The use without arguments is still possible, but users have to run a migration which adds a text column to  crono_jobs table. 

Arguments can be set as following:

```ruby
Crono.perform(TestJob, 'some', 'args').every 1.day, at: {hour: 12, min: 15}
``` 

For a Job like: 

```ruby
class TestJob
  def perform(some, args)
  end
end
```

I hope this change is conform with your idea of the project, if there is some problem please let me know.