### PR TITLE
add start stop and restart to cli

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     byebug (5.0.0)
       columnize (= 0.9.0)
     columnize (0.9.0)
+    daemons (1.2.2)
     diff-lcs (1.2.5)
     haml (4.0.6)
       tilt
@@ -69,6 +70,7 @@ DEPENDENCIES
   bundler (>= 1.0.0)
   byebug
   crono!
+  daemons
   haml
   rack-test
   rake (~> 10.0)
@@ -76,6 +78,3 @@ DEPENDENCIES
   sinatra
   sqlite3
   timecop (~> 0.7)
-
-BUNDLED WITH
-   1.10.6

--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ To run Crono daemon, in your Rails project root directory:
 
 crono usage:
 ```
-Usage: crono [options]
+Usage: crono [options] start|stop|restart|run
     -C, --cronotab PATH              Path to cronotab file (Default: config/cronotab.rb)
     -L, --logfile PATH               Path to writable logfile (Default: log/crono.log)
-    -P, --pidfile PATH               Path to pidfile (Default: tmp/pids/crono.pid)
-    -d, --[no-]daemonize             Daemonize process (Default: false)
-    -e, --environment ENV            Application environment (Default: development)
+        --piddir PATH                Path to piddir (Default: tmp/pids)
+    -N, --process_name name          Name of the process (Default: crono)
+    -m, --monitor                    Start monitor process for a deamon (Default false)
+    -e, --environment ENV Application environment (Default: development)
 ```
 
 

--- a/crono.gemspec
+++ b/crono.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'haml'
   spec.add_development_dependency 'rack-test'
+  spec.add_development_dependency 'daemons'
 end

--- a/lib/crono/cli.rb
+++ b/lib/crono/cli.rb
@@ -132,7 +132,7 @@ module Crono
           config.logfile = logfile
         end
 
-        opts.on("-P", "--pidfile PATH", "Path to pidfile (Default: #{config.pidfile})") do |pidfile|
+        opts.on("-P", "--pidfile PATH", "Deprecated! use --piddir with --process_name; Path to pidfile (Default: #{config.pidfile})") do |pidfile|
           config.pidfile = pidfile
         end
 
@@ -140,7 +140,7 @@ module Crono
           config.piddir = piddir
         end
 
-        opts.on("-N", "--process_name name", "Name of the process (Default: #{config.process_name})") do |process_name|
+        opts.on("-N", "--process_name NAME", "Name of the process (Default: #{config.process_name})") do |process_name|
           config.process_name = process_name
         end
 

--- a/lib/crono/config.rb
+++ b/lib/crono/config.rb
@@ -13,7 +13,6 @@ module Crono
     def initialize
       self.cronotab = CRONOTAB
       self.logfile  = LOGFILE
-      @pidfile = PIDFILE
       self.piddir = PIDDIR
       self.process_name = PROCESS_NAME
       self.daemonize = false

--- a/lib/crono/config.rb
+++ b/lib/crono/config.rb
@@ -4,18 +4,31 @@ module Crono
     CRONOTAB  = 'config/cronotab.rb'
     LOGFILE   = 'log/crono.log'
     PIDFILE   = 'tmp/pids/crono.pid'
+    PIDDIR    = 'tmp/pids'
+    PROCESS_NAME = 'crono'
 
-    attr_accessor :cronotab, :logfile, :pidfile, :daemonize, :environment
+    attr_accessor :cronotab, :logfile, :pidfile, :piddir, :process_name,
+                  :monitor, :daemonize, :deprecated_daemonize, :environment
 
     def initialize
       self.cronotab = CRONOTAB
       self.logfile  = LOGFILE
+      self.piddir = PIDDIR
+      self.process_name = PROCESS_NAME
       self.daemonize = false
+      self.deprecated_daemonize = false
+      self.monitor = false
       self.environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
+    def pidfile=(pidfile)
+      @pidfile = pidfile
+      self.process_name = Pathname.new(pidfile).basename(".*").to_s
+      self.piddir = Pathname.new(pidfile).dirname.to_s 
+    end
+
     def pidfile
-      @pidfile || (daemonize ? PIDFILE : nil)
+      @pidfile || (deprecated_daemonize ? PIDFILE : nil)
     end
   end
 end

--- a/lib/crono/config.rb
+++ b/lib/crono/config.rb
@@ -13,6 +13,7 @@ module Crono
     def initialize
       self.cronotab = CRONOTAB
       self.logfile  = LOGFILE
+      @pidfile = PIDFILE
       self.piddir = PIDDIR
       self.process_name = PROCESS_NAME
       self.daemonize = false

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -9,9 +9,24 @@ describe Crono::CLI do
       expect(cli).to receive(:load_rails)
       expect(cli).to receive(:start_working_loop)
       expect(cli).to receive(:parse_options)
+      expect(cli).to receive(:parse_command)
       expect(cli).to receive(:write_pid)
       expect(Crono::Cronotab).to receive(:process)
       cli.run
+    end
+    context 'should run as daemon' do
+
+      before {cli.config.daemonize = true}
+
+      it 'should initialize rails with #load_rails and start working loop' do
+        expect(cli).to receive(:load_rails)
+        expect(cli).to receive(:start_working_loop_in_daemon)
+        expect(cli).to receive(:parse_options)
+        expect(cli).to receive(:parse_command)
+        expect(cli).not_to receive(:write_pid)
+        expect(Crono::Cronotab).to receive(:process)
+        cli.run
+      end
     end
   end
 
@@ -31,14 +46,67 @@ describe Crono::CLI do
       expect(cli.config.pidfile).to be_eql 'tmp/pids/crono.0.log'
     end
 
-    it 'should set daemonize' do
+    it 'should set piddir' do
+      cli.send(:parse_options, ['--piddir', 'tmp/pids'])
+      expect(cli.config.piddir).to be_eql 'tmp/pids'
+    end
+
+    it 'should set process_name' do
+      cli.send(:parse_options, ['--process_name', 'crono0'])
+      expect(cli.config.process_name).to be_eql 'crono0'
+    end
+
+    it 'should set monitor' do
+      cli.send(:parse_options, ['--monitor'])
+      expect(cli.config.monitor).to be true
+    end
+
+    it 'should set deprecated_daemonize' do
       cli.send(:parse_options, ['--daemonize'])
-      expect(cli.config.daemonize).to be true
+      expect(cli.config.deprecated_daemonize).to be true
     end
 
     it 'should set environment' do
       cli.send(:parse_options, ['--environment', 'production'])
       expect(cli.config.environment).to be_eql('production')
+    end
+  end
+
+  describe '#parse_command' do
+
+    it 'should set daemonize on start' do
+      cli.send(:parse_command, ['start'])
+      expect(cli.config.daemonize).to be true
+    end
+
+    it 'should set daemonize on stop' do
+      cli.send(:parse_command, ['stop'])
+      expect(cli.config.daemonize).to be true
+    end
+
+    it 'should set daemonize on restart' do
+      cli.send(:parse_command, ['restart'])
+      expect(cli.config.daemonize).to be true
+    end
+
+    it 'should set daemonize on run' do
+      cli.send(:parse_command, ['run'])
+      expect(cli.config.daemonize).to be true
+    end
+
+    it 'should set daemonize on zap' do
+      cli.send(:parse_command, ['zap'])
+      expect(cli.config.daemonize).to be true
+    end
+
+    it 'should set daemonize on reload' do
+      cli.send(:parse_command, ['reload'])
+      expect(cli.config.daemonize).to be true
+    end
+
+    it 'should set daemonize on status' do
+      cli.send(:parse_command, ['status'])
+      expect(cli.config.daemonize).to be true
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -9,7 +9,11 @@ describe Crono::Config do
       expect(@config.cronotab).to be Crono::Config::CRONOTAB
       expect(@config.logfile).to be Crono::Config::LOGFILE
       expect(@config.pidfile).to be nil
+      expect(@config.piddir).to be Crono::Config::PIDDIR
+      expect(@config.process_name).to be Crono::Config::PROCESS_NAME
       expect(@config.daemonize).to be false
+      expect(@config.deprecated_daemonize).to be false
+      expect(@config.monitor).to be false
       expect(@config.environment).to be_eql ENV['RAILS_ENV']
     end
 
@@ -23,8 +27,8 @@ describe Crono::Config do
           specify { expect(pidfile).to be_nil }
         end
 
-        context "daemonize is true" do
-          before { config.daemonize = true }
+        context "deprecated_daemonize is true" do
+          before { config.deprecated_daemonize = true }
 
           specify { expect(pidfile).to eq Crono::Config::PIDFILE }
         end
@@ -36,7 +40,16 @@ describe Crono::Config do
         before { config.pidfile = path }
 
         specify { expect(pidfile).to eq path }
+
+        it "trys to set piddir" do
+          expect(config.piddir).to eq "foo/bar"
+        end
+
+        it "trys to set process_name" do
+          expect(config.process_name).to eq "pid"
+        end
       end
+
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -8,7 +8,6 @@ describe Crono::Config do
       @config = Crono::Config.new
       expect(@config.cronotab).to be Crono::Config::CRONOTAB
       expect(@config.logfile).to be Crono::Config::LOGFILE
-      expect(@config.pidfile).to be nil
       expect(@config.piddir).to be Crono::Config::PIDDIR
       expect(@config.process_name).to be Crono::Config::PROCESS_NAME
       expect(@config.daemonize).to be false


### PR DESCRIPTION
Hey,

I add more functionality to the CLI, know there is the possibility to stop and restart the daemon.
The old Interface can be still used without changes. If the user want to use the new functionality the user has to include the [daemon](https://github.com/thuehlinger/daemons) gem to the Rails project. This gem is used by delayed_job so the user might have it as dependency anyway. 

But still he is not forced to use crono with daemon-gem. The current way is still working. 

I needed to add a restart strategy for one of our use cases. 

Feel free to commend on my changes. I will also test my changes in production in the next weeks. 
