### PR TITLE
Fix for Rails 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     crono (1.0.0)
-      activerecord (~> 4.0)
-      activesupport (~> 4.0)
+      activerecord (>= 4.0)
+      activesupport (>= 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/crono.gemspec
+++ b/crono.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.0'
-  spec.add_runtime_dependency 'activerecord', '~> 4.0'
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
+  spec.add_runtime_dependency 'activerecord', '>= 4.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'bundler', '>= 1.0.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Releasing the activerecord and activesupport gems strict versioning allows installing crono gem in a Rails 5 beta 3 app.

Specs are passing.