### PR TITLE
deprecate need to config your app name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Here's an example of a Rake Task within a job:
 ```ruby
 # config/cronotab.rb
 require 'rake'
-# Be sure to change AppName to your application name!
-AppName::Application.load_tasks
+
+Rails.app_class.load_tasks
 
 class Test
   def perform


### PR DESCRIPTION
Instead of `<AppName>::Application.load_tasks` the same can be achieved by `Rails.app_class.load_tasks`, therefore not requiring the user to configure the AppName. Less margin for errors :)