### PR TITLE
schedule on: today if at: time not passed

### DIFF
--- a/lib/crono/period.rb
+++ b/lib/crono/period.rb
@@ -48,6 +48,7 @@ module Crono
     def initial_day
       return Time.now unless @on
       day = Time.now.beginning_of_week.advance(days: @on)
+      day = day.change(time_atts)
       return day if day.future?
       @period.from_now.beginning_of_week.advance(days: @on)
     end

--- a/spec/period_spec.rb
+++ b/spec/period_spec.rb
@@ -49,6 +49,16 @@ describe Crono::Period do
           expect(@period.next).to be_eql(tuesday)
         end
       end
+
+      it 'should return today on the first run if not too late' do
+        @period = Crono::Period.new(1.week, on: :sunday, at: '22:00')
+        Timecop.freeze(Time.now.beginning_of_week.advance(days: 6)
+                           .change(hour: 21, min: 0)) do
+          expect(@period.next).to be_eql(
+            Time.now.beginning_of_week.advance(days: 6).change(hour: 22, min: 0)
+          )
+        end
+      end
     end
 
     context 'in daily basis' do


### PR DESCRIPTION
I noticed with my weekly tasks where a time of day was specified (e.g. on: :sunday, at: '22:00') , and Crono was started on that day (e.g. Sunday), but before the schedule time (e.g. 21:00) that the job would be scheduled for one week later rather than the same day. With heroku restarts my jobs scheduled for later in the day never got to run!

See accompany test case (which fails without the fix) and the trivial fix.
