### PR TITLE
fix: rails 4.0.x

### DIFF
--- a/lib/crono/period.rb
+++ b/lib/crono/period.rb
@@ -78,7 +78,8 @@ module Crono
     end
 
     def time_atts
-      { hour: @at_hour, min: @at_min }.compact
+      atts = { hour: @at_hour, min: @at_min }
+      atts.respond_to?(:compact) ? atts.compact : atts.select { |_, value| !value.nil? }
     end
   end
 end


### PR DESCRIPTION
Hash in rails 4.0.x does not have `compact` method (and in the description it says crono works for rails 4*).

This PR fix the related issue https://github.com/plashchynski/crono/issues/43