### PR TITLE
Fixed race condition when starting jobs

### DIFF
--- a/lib/crono/cli.rb
+++ b/lib/crono/cli.rb
@@ -120,7 +120,8 @@ module Crono
     def start_working_loop
       loop do
         next_time, jobs = Crono.scheduler.next_jobs
-        sleep(next_time - Time.zone.now) if next_time > Time.zone.now
+        now = Time.zone.now
+        sleep(next_time - now) if next_time > now
         jobs.each(&:perform)
       end
     end


### PR DESCRIPTION
Calling Time.zone.now in the if statement and while calculating sleep delay sometimes resulted in an exception with message "time interval must be positive".
This happened if job was about to start and we needed to sleep for a really short period of time + server was under high load.
First the application was checking if difference between current time and scheduled run time was positive.
If the expression returned true, sleep was called, but required delay was calculated once again and could result in a negative value being passed to the sleep function.