### PR TITLE
Use Ruby 3 conversion kwargs

### DIFF
--- a/lib/crono/job.rb
+++ b/lib/crono/job.rb
@@ -76,7 +76,7 @@ module Crono
     end
 
     def perform_job
-      performer.new.perform *JSON.parse(job_args)
+      performer.new.perform JSON.parse(job_args)
     rescue StandardError => e
       handle_job_fail(e)
     else

--- a/lib/crono/performer_proxy.rb
+++ b/lib/crono/performer_proxy.rb
@@ -7,8 +7,8 @@ module Crono
       @job_args = job_args
     end
 
-    def every(period, *args)
-      @job = Job.new(@performer, Period.new(period, *args), @job_args, @options)
+    def every(period, **options)
+      @job = Job.new(@performer, Period.new(period, **options), @job_args, @options)
       @scheduler.add_job(@job)
       self
     end


### PR DESCRIPTION
Small fixes to use [separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).