### PR TITLE
Repair "wrong number of arguments" error.

### DIFF
--- a/lib/crono/performer_proxy.rb
+++ b/lib/crono/performer_proxy.rb
@@ -7,8 +7,13 @@ module Crono
       @job_args = job_args
     end
 
-    def every(period, *args)
-      @job = Job.new(@performer, Period.new(period, *args), @job_args, @options)
+    def every(period, at: nil, on: nil, within: nil)
+      @job = Job.new(
+        @performer,
+        Period.new(period, at: at, on: on, within: within),
+        @job_args,
+        @options,
+      )
       @scheduler.add_job(@job)
       self
     end


### PR DESCRIPTION
For some reason, the argument destructuring `*args` is causing an error.
Passing variables along manually helps the code run properly.

```
[grace@chesapeake reap]$ bundle exec crono RAILS_ENV=development
wrong number of arguments (given 2, expected 1)
/home/grace/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/crono-1.1.2/lib/crono/period.rb:7:in `initialize'
/home/grace/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/crono-1.1.2/lib/crono/performer_proxy.rb:11:in `new'
/home/grace/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/crono-1.1.2/lib/crono/performer_proxy.rb:11:in `every'
/home/grace/Desktop/assembled.app/reap/config/cronotab.rb:14:in `<main>'
```