### PR TITLE
Remove Sprockets hard dependency, allow Propshaft

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     crono (2.0.1)
       rails (>= 5.2.8)
-      sprockets-rails
 
 GEM
   remote: https://rubygems.org/
@@ -184,13 +183,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.0)
       tilt (~> 2.0)
-    sprockets (4.1.1)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     strscan (3.0.4)
     temple (0.8.2)

--- a/crono.gemspec
+++ b/crono.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'rails', '>= 5.2.8'
-  s.add_dependency 'sprockets-rails'
   s.add_development_dependency 'rake', '>= 13.0.1'
   s.add_development_dependency 'bundler', '>= 2'
   s.add_development_dependency 'rspec', '>= 3.10'

--- a/lib/crono.rb
+++ b/lib/crono.rb
@@ -3,7 +3,6 @@ module Crono
 end
 
 require 'rails'
-require 'sprockets/railtie'
 require 'active_support/all'
 require 'crono/version'
 require 'crono/engine'

--- a/lib/crono/engine.rb
+++ b/lib/crono/engine.rb
@@ -3,7 +3,11 @@ module Crono
     isolate_namespace Crono
 
     initializer 'crono.assets.precompile' do |app|
-      app.config.assets.precompile += %w( crono/application.css crono/materialize.min.css )
+      if app.config.respond_to?(:assets)
+        app.config.assets.precompile += %w( crono/application.css crono/materialize.min.css )
+      else
+        fail "Crono requires either Propshaft or Sprockets to be installed."
+      end
     end
 
     config.generators do |g|


### PR DESCRIPTION
This removes `sprockets-rails` from dependencies, allowing usage with Propshaft, which is a significantly lighter asset pipeline (10x less code than Sprockets).

This is a breaking change for people using Crono without having `sprockets-rails` in their Gemfiles.

Fixes #122
